### PR TITLE
fix:api port change on docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - postgres
       - redis
     ports:
-      - "8080:8080"
+      - "80:80"
     networks:
       - backend-network
 


### PR DESCRIPTION
The docker-compose API port is matched with the HTTP listen port of the API